### PR TITLE
Add 'cd -' command to test

### DIFF
--- a/.autograding/__tests__/test1.js
+++ b/.autograding/__tests__/test1.js
@@ -79,7 +79,7 @@ describe('commands', () => {
   });
   
   test('deleted file3.txt', () => {
-    expect(commands.find(command => command.endsWith('cd ..'))).toBeTruthy();
+    expect(commands.find(command => (command.endsWith('cd ..') || command.endsWith('cd -')))).toBeTruthy();
     expect(commands.find(command => command.endsWith('rm file3.txt'))).toBeTruthy();
   });
 


### PR DESCRIPTION
Added a test for `cd -` in the jest test script as some students will have used this shortcut instead of `cd ..` to traverse a directory. 